### PR TITLE
feat: add multi-database support (PostgreSQL, MySQL, SQLite)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,17 @@
-# PostgreSQL Configuration
-POSTGRES_HOST=localhost
-POSTGRES_PORT=5432
-POSTGRES_USER=postgres
-POSTGRES_PASSWORD=postgres
-POSTGRES_DB=wagateway
+# Database Configuration
+# Supports: PostgreSQL, MySQL, SQLite
+# Examples:
+#   DATABASE_URL=postgres://user:password@localhost:5432/wagateway
+#   DATABASE_URL=mysql://user:password@localhost:3306/wagateway
+#   DATABASE_URL=sqlite://wa-rs.db
+DATABASE_URL=postgres://postgres:postgres@localhost:5432/wagateway
+
+# Legacy PostgreSQL config (used as fallback if DATABASE_URL is not set)
+# POSTGRES_HOST=localhost
+# POSTGRES_PORT=5432
+# POSTGRES_USER=postgres
+# POSTGRES_PASSWORD=postgres
+# POSTGRES_DB=wagateway
 
 # JWT Configuration
 JWT_SECRET=your-super-secret-jwt-key-change-in-production

--- a/.env.example
+++ b/.env.example
@@ -4,17 +4,17 @@
 #   DATABASE_URL=postgres://user:password@localhost:5432/wagateway
 #   DATABASE_URL=mysql://user:password@localhost:3306/wagateway
 #   DATABASE_URL=sqlite://wa-rs.db
-DATABASE_URL=postgres://postgres:postgres@localhost:5432/wagateway
+# DATABASE_URL=postgres://user:password@localhost:5432/wagateway
 
 # Legacy PostgreSQL config (used as fallback if DATABASE_URL is not set)
 # POSTGRES_HOST=localhost
 # POSTGRES_PORT=5432
 # POSTGRES_USER=postgres
-# POSTGRES_PASSWORD=postgres
+# POSTGRES_PASSWORD=
 # POSTGRES_DB=wagateway
 
 # JWT Configuration
-JWT_SECRET=your-super-secret-jwt-key-change-in-production
+# JWT_SECRET=change-me-in-production
 
 # WhatsApp Session Storage
 WHATSAPP_STORAGE_PATH=./whatsapp_sessions

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,6 +53,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -150,6 +156,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "atoi"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -266,6 +281,9 @@ name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "block-buffer"
@@ -447,6 +465,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -469,6 +502,15 @@ name = "crossbeam-epoch"
 version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -581,41 +623,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
-name = "deadpool"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
-dependencies = [
- "deadpool-runtime",
- "lazy_static",
- "num_cpus",
- "tokio",
-]
-
-[[package]]
-name = "deadpool-postgres"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d697d376cbfa018c23eb4caab1fd1883dd9c906a8c034e8d9a3cb06a7e0bef9"
-dependencies = [
- "async-trait",
- "deadpool",
- "getrandom 0.2.17",
- "tokio",
- "tokio-postgres",
- "tracing",
-]
-
-[[package]]
-name = "deadpool-runtime"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
-dependencies = [
- "tokio",
-]
-
-[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -722,6 +729,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
  "subtle",
 ]
@@ -799,6 +807,9 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "encoding_rs"
@@ -845,6 +856,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "etcetera"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
+dependencies = [
+ "cfg-if",
+ "home",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "event-listener"
 version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -864,12 +886,6 @@ dependencies = [
  "event-listener",
  "pin-project-lite",
 ]
-
-[[package]]
-name = "fallible-iterator"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 
 [[package]]
 name = "fastrand"
@@ -903,6 +919,17 @@ checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "miniz_oxide",
  "zlib-rs",
+]
+
+[[package]]
+name = "flume"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "spin",
 ]
 
 [[package]]
@@ -975,6 +1002,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-intrusive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d930c203dd0b6ff06e0201a4a2fe9149b43c684fd4420555b26d21b1a02956f"
+dependencies = [
+ "futures-core",
+ "lock_api",
+ "parking_lot",
+]
+
+[[package]]
 name = "futures-io"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1039,7 +1077,7 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasi",
  "wasm-bindgen",
 ]
 
@@ -1092,6 +1130,8 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash 0.1.5",
 ]
 
@@ -1105,16 +1145,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashlink"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+dependencies = [
+ "hashbrown 0.15.5",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
-name = "hermit-abi"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -1138,6 +1181,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest",
+]
+
+[[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1221,7 +1273,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -1468,6 +1520,9 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin",
+]
 
 [[package]]
 name = "leb128fmt"
@@ -1482,6 +1537,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
 
 [[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
 name = "libredox"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1489,14 +1550,16 @@ checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
 dependencies = [
  "bitflags",
  "libc",
+ "redox_syscall 0.7.3",
 ]
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.35.0"
+version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "133c182a6a2c87864fe97778797e46c7e999672690dc9fa3ee8e241aa4a9c13f"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
 dependencies = [
+ "cc",
  "pkg-config",
  "vcpkg",
 ]
@@ -1631,7 +1694,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
- "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasi",
  "windows-sys 0.61.2",
 ]
 
@@ -1722,6 +1785,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint-dig"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
+dependencies = [
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand 0.8.5",
+ "smallvec",
+ "zeroize",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1737,40 +1816,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
-]
-
-[[package]]
-name = "num_cpus"
-version = "1.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
-dependencies = [
- "hermit-abi",
- "libc",
-]
-
-[[package]]
-name = "objc2-core-foundation"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
-name = "objc2-system-configuration"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7216bd11cbda54ccabcab84d523dc93b858ec75ecfb3a7d89513fa22464da396"
-dependencies = [
- "objc2-core-foundation",
+ "libm",
 ]
 
 [[package]]
@@ -1821,7 +1884,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
  "windows-link",
 ]
@@ -1879,7 +1942,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
 dependencies = [
  "phf_shared",
- "serde",
 ]
 
 [[package]]
@@ -1944,6 +2006,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der",
+ "pkcs8",
+ "spki",
+]
+
+[[package]]
 name = "pkcs8"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1976,37 +2049,6 @@ name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
-
-[[package]]
-name = "postgres-protocol"
-version = "0.6.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ee9dd5fe15055d2b6806f4736aa0c9637217074e224bbec46d4041b91bb9491"
-dependencies = [
- "base64",
- "byteorder",
- "bytes",
- "fallible-iterator",
- "hmac",
- "md-5",
- "memchr",
- "rand 0.9.2",
- "sha2",
- "stringprep",
-]
-
-[[package]]
-name = "postgres-types"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54b858f82211e84682fecd373f68e1ceae642d8d751a1ebd13f33de6257b3e20"
-dependencies = [
- "bytes",
- "chrono",
- "fallible-iterator",
- "postgres-protocol",
- "uuid",
-]
 
 [[package]]
 name = "potential_utf"
@@ -2276,6 +2318,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2339,7 +2390,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -2354,6 +2405,26 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rsa"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
+dependencies = [
+ "const-oid",
+ "digest",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "signature",
+ "spki",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -2810,6 +2881,9 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "socket2"
@@ -2826,6 +2900,9 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
 
 [[package]]
 name = "spki"
@@ -2847,6 +2924,204 @@ dependencies = [
  "js-sys",
  "rsqlite-vfs",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "sqlx"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fefb893899429669dcdd979aff487bd78f4064e5e7907e4269081e0ef7d97dc"
+dependencies = [
+ "sqlx-core",
+ "sqlx-macros",
+ "sqlx-mysql",
+ "sqlx-postgres",
+ "sqlx-sqlite",
+]
+
+[[package]]
+name = "sqlx-core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee6798b1838b6a0f69c007c133b8df5866302197e404e8b6ee8ed3e3a5e68dc6"
+dependencies = [
+ "base64",
+ "bytes",
+ "chrono",
+ "crc",
+ "crossbeam-queue",
+ "either",
+ "event-listener",
+ "futures-core",
+ "futures-intrusive",
+ "futures-io",
+ "futures-util",
+ "hashbrown 0.15.5",
+ "hashlink",
+ "indexmap",
+ "log",
+ "memchr",
+ "once_cell",
+ "percent-encoding",
+ "rustls",
+ "serde",
+ "serde_json",
+ "sha2",
+ "smallvec",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "url",
+ "uuid",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "sqlx-macros"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2d452988ccaacfbf5e0bdbc348fb91d7c8af5bee192173ac3636b5fb6e6715d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "sqlx-core",
+ "sqlx-macros-core",
+ "syn",
+]
+
+[[package]]
+name = "sqlx-macros-core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19a9c1841124ac5a61741f96e1d9e2ec77424bf323962dd894bdb93f37d5219b"
+dependencies = [
+ "dotenvy",
+ "either",
+ "heck",
+ "hex",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "sha2",
+ "sqlx-core",
+ "sqlx-mysql",
+ "sqlx-postgres",
+ "sqlx-sqlite",
+ "syn",
+ "tokio",
+ "url",
+]
+
+[[package]]
+name = "sqlx-mysql"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
+dependencies = [
+ "atoi",
+ "base64",
+ "bitflags",
+ "byteorder",
+ "bytes",
+ "chrono",
+ "crc",
+ "digest",
+ "dotenvy",
+ "either",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-util",
+ "generic-array",
+ "hex",
+ "hkdf",
+ "hmac",
+ "itoa",
+ "log",
+ "md-5",
+ "memchr",
+ "once_cell",
+ "percent-encoding",
+ "rand 0.8.5",
+ "rsa",
+ "serde",
+ "sha1",
+ "sha2",
+ "smallvec",
+ "sqlx-core",
+ "stringprep",
+ "thiserror 2.0.18",
+ "tracing",
+ "uuid",
+ "whoami",
+]
+
+[[package]]
+name = "sqlx-postgres"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
+dependencies = [
+ "atoi",
+ "base64",
+ "bitflags",
+ "byteorder",
+ "chrono",
+ "crc",
+ "dotenvy",
+ "etcetera",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "hex",
+ "hkdf",
+ "hmac",
+ "home",
+ "itoa",
+ "log",
+ "md-5",
+ "memchr",
+ "once_cell",
+ "rand 0.8.5",
+ "serde",
+ "serde_json",
+ "sha2",
+ "smallvec",
+ "sqlx-core",
+ "stringprep",
+ "thiserror 2.0.18",
+ "tracing",
+ "uuid",
+ "whoami",
+]
+
+[[package]]
+name = "sqlx-sqlite"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2d12fe70b2c1b4401038055f90f151b78208de1f9f89a7dbfd41587a10c3eea"
+dependencies = [
+ "atoi",
+ "chrono",
+ "flume",
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-intrusive",
+ "futures-util",
+ "libsqlite3-sys",
+ "log",
+ "percent-encoding",
+ "serde",
+ "serde_urlencoded",
+ "sqlx-core",
+ "thiserror 2.0.18",
+ "tracing",
+ "url",
+ "uuid",
 ]
 
 [[package]]
@@ -3062,38 +3337,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-postgres"
-version = "0.7.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcea47c8f71744367793f16c2db1f11cb859d28f436bdb4ca9193eb1f787ee42"
-dependencies = [
- "async-trait",
- "byteorder",
- "bytes",
- "fallible-iterator",
- "futures-channel",
- "futures-util",
- "log",
- "parking_lot",
- "percent-encoding",
- "phf",
- "pin-project-lite",
- "postgres-protocol",
- "postgres-types",
- "rand 0.9.2",
- "socket2",
- "tokio",
- "tokio-util",
- "whoami",
-]
-
-[[package]]
 name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
  "tokio",
 ]
 
@@ -3411,7 +3671,7 @@ dependencies = [
  "serde_json",
  "ureq-proto",
  "utf-8",
- "webpki-roots",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -3540,7 +3800,6 @@ dependencies = [
  "bytes",
  "chrono",
  "dashmap",
- "deadpool-postgres",
  "dotenvy",
  "futures",
  "hex",
@@ -3552,9 +3811,9 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "sqlx",
  "thiserror 2.0.18",
  "tokio",
- "tokio-postgres",
  "tower",
  "tower-http",
  "tracing",
@@ -3743,15 +4002,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
-name = "wasi"
-version = "0.14.7+wasi-0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c"
-dependencies = [
- "wasip2",
-]
-
-[[package]]
 name = "wasip2"
 version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3771,12 +4021,9 @@ dependencies = [
 
 [[package]]
 name = "wasite"
-version = "1.0.2"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66fe902b4a6b8028a753d5424909b764ccf79b7a209eac9bf97e59cda9f71a42"
-dependencies = [
- "wasi 0.14.7+wasi-0.2.4",
-]
+checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
@@ -3893,6 +4140,15 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.6",
+]
+
+[[package]]
+name = "webpki-roots"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
@@ -3967,7 +4223,7 @@ dependencies = [
  "tokio-rustls",
  "tokio-websockets 0.13.1",
  "wacore",
- "webpki-roots",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -3984,15 +4240,12 @@ dependencies = [
 
 [[package]]
 name = "whoami"
-version = "2.1.1"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6a5b12f9df4f978d2cfdb1bd3bac52433f44393342d7ee9c25f5a1c14c0f45d"
+checksum = "5d4a4db5077702ca3015d3d02d74974948aba2ad9e12ab7df718ee64ccd7e97d"
 dependencies = [
- "libc",
  "libredox",
- "objc2-system-configuration",
  "wasite",
- "web-sys",
 ]
 
 [[package]]
@@ -4065,6 +4318,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -4088,6 +4350,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -4125,6 +4402,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -4137,6 +4420,12 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -4146,6 +4435,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4173,6 +4468,12 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -4182,6 +4483,12 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -4197,6 +4504,12 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -4206,6 +4519,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,9 +33,17 @@ serde_json = "1"
 utoipa = { version = "5", features = ["axum_extras"] }
 utoipa-swagger-ui = { version = "9", features = ["axum"] }
 
-# Database (PostgreSQL)
-tokio-postgres = { version = "0.7", features = ["with-chrono-0_4", "with-uuid-1"] }
-deadpool-postgres = "0.14"
+# Database (multi-backend: PostgreSQL, MySQL, SQLite)
+sqlx = { version = "0.8", features = [
+    "runtime-tokio",
+    "tls-rustls",
+    "any",
+    "postgres",
+    "mysql",
+    "sqlite",
+    "chrono",
+    "uuid",
+] }
 
 # Environment
 dotenvy = "0.15"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,11 +34,7 @@ services:
       dockerfile: Dockerfile
     container_name: wagateway-api
     environment:
-      POSTGRES_HOST: postgres
-      POSTGRES_PORT: 5432
-      POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: postgres
-      POSTGRES_DB: wagateway
+      DATABASE_URL: postgres://postgres:postgres@postgres:5432/wagateway
       JWT_SECRET: ${JWT_SECRET:-your-super-secret-jwt-key-change-in-production}
       SUPERADMIN_TOKEN: ${SUPERADMIN_TOKEN:-}
       WHATSAPP_STORAGE_PATH: /app/whatsapp_sessions

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -2,3 +2,75 @@ pub mod schema;
 pub mod session;
 
 pub use session::SessionManager;
+
+use sqlx::AnyPool;
+
+/// Create a database pool from DATABASE_URL env var.
+/// Supports: postgres://, mysql://, sqlite://
+///
+/// Falls back to legacy POSTGRES_* env vars if DATABASE_URL is not set.
+pub async fn create_pool() -> anyhow::Result<AnyPool> {
+    // Install all drivers
+    sqlx::any::install_default_drivers();
+
+    let database_url = if let Ok(url) = std::env::var("DATABASE_URL") {
+        url
+    } else {
+        // Fallback: build URL from legacy POSTGRES_* vars
+        let host = std::env::var("POSTGRES_HOST").unwrap_or_else(|_| "localhost".to_string());
+        let port = std::env::var("POSTGRES_PORT").unwrap_or_else(|_| "5432".to_string());
+        let user = std::env::var("POSTGRES_USER").unwrap_or_else(|_| "postgres".to_string());
+        let password =
+            std::env::var("POSTGRES_PASSWORD").unwrap_or_else(|_| "postgres".to_string());
+        let db = std::env::var("POSTGRES_DB").unwrap_or_else(|_| "wagateway".to_string());
+
+        format!("postgres://{}:{}@{}:{}/{}", user, password, host, port, db)
+    };
+
+    let backend_name = if database_url.starts_with("postgres") {
+        "PostgreSQL"
+    } else if database_url.starts_with("mysql") {
+        "MySQL"
+    } else if database_url.starts_with("sqlite") {
+        "SQLite"
+    } else {
+        "Unknown"
+    };
+
+    // Mask password in log
+    let masked_url = mask_url(&database_url);
+    tracing::info!("Connecting to {} ({})", backend_name, masked_url);
+
+    // SQLite: ensure create mode is enabled
+    let connect_url = if database_url.starts_with("sqlite") && !database_url.contains("mode=") {
+        if database_url.contains('?') {
+            format!("{}&mode=rwc", database_url)
+        } else {
+            format!("{}?mode=rwc", database_url)
+        }
+    } else {
+        database_url.clone()
+    };
+
+    let pool = AnyPool::connect(&connect_url).await?;
+
+    tracing::info!("Connected to {}", backend_name);
+
+    Ok(pool)
+}
+
+fn mask_url(url: &str) -> String {
+    // Mask password in connection URL for safe logging
+    if let Some(at_pos) = url.find('@') {
+        if let Some(colon_pos) = url[..at_pos].rfind(':') {
+            if let Some(slash_pos) = url[..colon_pos].rfind('/') {
+                let prefix = &url[..slash_pos + 1];
+                let user_end = colon_pos;
+                let user = &url[slash_pos + 1..user_end];
+                let suffix = &url[at_pos..];
+                return format!("{}{}:***{}", prefix, user, suffix);
+            }
+        }
+    }
+    url.to_string()
+}

--- a/src/db/schema.rs
+++ b/src/db/schema.rs
@@ -1,52 +1,165 @@
-use deadpool_postgres::Pool;
+use sqlx::AnyPool;
 
-pub async fn init_schema(pool: &Pool) -> anyhow::Result<()> {
-    let client = pool.get().await?;
+pub async fn init_schema(pool: &AnyPool) -> anyhow::Result<()> {
+    let backend = detect_backend(pool);
 
-    client
-        .execute(
-            r#"
-            CREATE TABLE IF NOT EXISTS sessions (
-                id VARCHAR(255) PRIMARY KEY,
-                name VARCHAR(255),
-                storage_path TEXT NOT NULL,
-                phone_number VARCHAR(50),
-                push_name VARCHAR(255),
-                status VARCHAR(50) NOT NULL DEFAULT 'disconnected',
-                is_logged_in BOOLEAN NOT NULL DEFAULT FALSE,
-                created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-                updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-                last_connected_at TIMESTAMPTZ
-            )
-            "#,
-            &[],
+    match backend {
+        DbBackend::Postgres => init_postgres(pool).await,
+        DbBackend::MySQL => init_mysql(pool).await,
+        DbBackend::SQLite => init_sqlite(pool).await,
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum DbBackend {
+    Postgres,
+    MySQL,
+    SQLite,
+}
+
+fn detect_backend(pool: &AnyPool) -> DbBackend {
+    let url = std::env::var("DATABASE_URL").unwrap_or_default();
+    if url.starts_with("postgres") {
+        DbBackend::Postgres
+    } else if url.starts_with("mysql") {
+        DbBackend::MySQL
+    } else if url.starts_with("sqlite") {
+        DbBackend::SQLite
+    } else {
+        // Fallback: check pool kind name
+        let name = format!("{:?}", pool);
+        if name.contains("Postgres") {
+            DbBackend::Postgres
+        } else if name.contains("MySql") {
+            DbBackend::MySQL
+        } else {
+            DbBackend::SQLite
+        }
+    }
+}
+
+async fn init_postgres(pool: &AnyPool) -> anyhow::Result<()> {
+    sqlx::query(
+        r#"
+        CREATE TABLE IF NOT EXISTS sessions (
+            id VARCHAR(255) PRIMARY KEY,
+            name VARCHAR(255),
+            storage_path TEXT NOT NULL,
+            phone_number VARCHAR(50),
+            push_name VARCHAR(255),
+            status VARCHAR(50) NOT NULL DEFAULT 'disconnected',
+            is_logged_in BOOLEAN NOT NULL DEFAULT FALSE,
+            created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            last_connected_at TIMESTAMPTZ
         )
+        "#,
+    )
+    .execute(pool)
+    .await?;
+
+    sqlx::query(
+        r#"
+        CREATE TABLE IF NOT EXISTS webhooks (
+            id VARCHAR(255) PRIMARY KEY,
+            session_id VARCHAR(255) NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+            url TEXT NOT NULL,
+            events TEXT NOT NULL DEFAULT '',
+            secret VARCHAR(255),
+            enabled BOOLEAN NOT NULL DEFAULT TRUE,
+            created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+        )
+        "#,
+    )
+    .execute(pool)
+    .await?;
+
+    sqlx::query("CREATE INDEX IF NOT EXISTS idx_webhooks_session_id ON webhooks(session_id)")
+        .execute(pool)
         .await?;
 
-    client
-        .execute(
-            r#"
-            CREATE TABLE IF NOT EXISTS webhooks (
-                id VARCHAR(255) PRIMARY KEY,
-                session_id VARCHAR(255) NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
-                url TEXT NOT NULL,
-                events TEXT[] NOT NULL DEFAULT '{}',
-                secret VARCHAR(255),
-                enabled BOOLEAN NOT NULL DEFAULT TRUE,
-                created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
-            )
-            "#,
-            &[],
-        )
-        .await?;
+    Ok(())
+}
 
-    client
-        .execute(
-            r#"
-            CREATE INDEX IF NOT EXISTS idx_webhooks_session_id ON webhooks(session_id)
-            "#,
-            &[],
+async fn init_mysql(pool: &AnyPool) -> anyhow::Result<()> {
+    sqlx::query(
+        r#"
+        CREATE TABLE IF NOT EXISTS sessions (
+            id VARCHAR(255) PRIMARY KEY,
+            name VARCHAR(255),
+            storage_path TEXT NOT NULL,
+            phone_number VARCHAR(50),
+            push_name VARCHAR(255),
+            status VARCHAR(50) NOT NULL DEFAULT 'disconnected',
+            is_logged_in TINYINT(1) NOT NULL DEFAULT 0,
+            created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+            last_connected_at TIMESTAMP NULL
         )
+        "#,
+    )
+    .execute(pool)
+    .await?;
+
+    sqlx::query(
+        r#"
+        CREATE TABLE IF NOT EXISTS webhooks (
+            id VARCHAR(255) PRIMARY KEY,
+            session_id VARCHAR(255) NOT NULL,
+            url TEXT NOT NULL,
+            events TEXT NOT NULL DEFAULT '',
+            secret VARCHAR(255),
+            enabled TINYINT(1) NOT NULL DEFAULT 1,
+            created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            FOREIGN KEY (session_id) REFERENCES sessions(id) ON DELETE CASCADE,
+            INDEX idx_webhooks_session_id (session_id)
+        )
+        "#,
+    )
+    .execute(pool)
+    .await?;
+
+    Ok(())
+}
+
+async fn init_sqlite(pool: &AnyPool) -> anyhow::Result<()> {
+    sqlx::query(
+        r#"
+        CREATE TABLE IF NOT EXISTS sessions (
+            id TEXT PRIMARY KEY,
+            name TEXT,
+            storage_path TEXT NOT NULL,
+            phone_number TEXT,
+            push_name TEXT,
+            status TEXT NOT NULL DEFAULT 'disconnected',
+            is_logged_in INTEGER NOT NULL DEFAULT 0,
+            created_at TEXT NOT NULL DEFAULT (datetime('now')),
+            updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+            last_connected_at TEXT
+        )
+        "#,
+    )
+    .execute(pool)
+    .await?;
+
+    sqlx::query(
+        r#"
+        CREATE TABLE IF NOT EXISTS webhooks (
+            id TEXT PRIMARY KEY,
+            session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+            url TEXT NOT NULL,
+            events TEXT NOT NULL DEFAULT '',
+            secret TEXT,
+            enabled INTEGER NOT NULL DEFAULT 1,
+            created_at TEXT NOT NULL DEFAULT (datetime('now'))
+        )
+        "#,
+    )
+    .execute(pool)
+    .await?;
+
+    sqlx::query("CREATE INDEX IF NOT EXISTS idx_webhooks_session_id ON webhooks(session_id)")
+        .execute(pool)
         .await?;
 
     Ok(())

--- a/src/db/session.rs
+++ b/src/db/session.rs
@@ -59,30 +59,27 @@ impl SessionManager {
     }
 
     pub async fn get_session(&self, id: &str) -> anyhow::Result<Option<SessionInfo>> {
-        let row: Option<AnyRow> =
-            sqlx::query("SELECT * FROM sessions WHERE id = ?")
-                .bind(id)
-                .fetch_optional(&self.pool)
-                .await?;
+        let row: Option<AnyRow> = sqlx::query("SELECT * FROM sessions WHERE id = ?")
+            .bind(id)
+            .fetch_optional(&self.pool)
+            .await?;
 
         Ok(row.map(|r| self.row_to_session_info(&r)))
     }
 
     pub async fn get_storage_path(&self, id: &str) -> anyhow::Result<Option<String>> {
-        let row: Option<AnyRow> =
-            sqlx::query("SELECT storage_path FROM sessions WHERE id = ?")
-                .bind(id)
-                .fetch_optional(&self.pool)
-                .await?;
+        let row: Option<AnyRow> = sqlx::query("SELECT storage_path FROM sessions WHERE id = ?")
+            .bind(id)
+            .fetch_optional(&self.pool)
+            .await?;
 
         Ok(row.map(|r| r.get::<String, _>("storage_path")))
     }
 
     pub async fn list_sessions(&self) -> anyhow::Result<Vec<SessionInfo>> {
-        let rows: Vec<AnyRow> =
-            sqlx::query("SELECT * FROM sessions ORDER BY created_at DESC")
-                .fetch_all(&self.pool)
-                .await?;
+        let rows: Vec<AnyRow> = sqlx::query("SELECT * FROM sessions ORDER BY created_at DESC")
+            .fetch_all(&self.pool)
+            .await?;
 
         Ok(rows.iter().map(|r| self.row_to_session_info(r)).collect())
     }
@@ -220,11 +217,10 @@ impl SessionManager {
         &self,
         session_id: &str,
     ) -> anyhow::Result<Vec<(String, WebhookConfig)>> {
-        let rows: Vec<AnyRow> =
-            sqlx::query("SELECT * FROM webhooks WHERE session_id = ?")
-                .bind(session_id)
-                .fetch_all(&self.pool)
-                .await?;
+        let rows: Vec<AnyRow> = sqlx::query("SELECT * FROM webhooks WHERE session_id = ?")
+            .bind(session_id)
+            .fetch_all(&self.pool)
+            .await?;
 
         Ok(rows
             .iter()
@@ -272,12 +268,11 @@ impl SessionManager {
         let last_connected_at = self.get_timestamp(row, "last_connected_at");
 
         // Handle bool - SQLite uses integer
-        let is_logged_in: bool = row.try_get::<bool, _>("is_logged_in")
-            .unwrap_or_else(|_| {
-                row.try_get::<i32, _>("is_logged_in")
-                    .map(|v| v != 0)
-                    .unwrap_or(false)
-            });
+        let is_logged_in: bool = row.try_get::<bool, _>("is_logged_in").unwrap_or_else(|_| {
+            row.try_get::<i32, _>("is_logged_in")
+                .map(|v| v != 0)
+                .unwrap_or(false)
+        });
 
         SessionInfo {
             id: row.get("id"),
@@ -308,7 +303,7 @@ impl SessionManager {
                 "%Y-%m-%d %H:%M:%S%.f%:z", // Postgres TIMESTAMPTZ
                 "%Y-%m-%dT%H:%M:%S%.f%:z", // ISO 8601 with tz
                 "%Y-%m-%d %H:%M:%S%.f",    // MySQL/SQLite with fractional
-                "%Y-%m-%d %H:%M:%S",        // Basic datetime
+                "%Y-%m-%d %H:%M:%S",       // Basic datetime
                 "%Y-%m-%dT%H:%M:%S%.f",    // ISO 8601 no tz
                 "%Y-%m-%dT%H:%M:%S",       // ISO 8601 basic
             ] {

--- a/src/db/session.rs
+++ b/src/db/session.rs
@@ -1,17 +1,39 @@
-use chrono::{DateTime, Utc};
-use deadpool_postgres::Pool;
+use sqlx::any::AnyRow;
+use sqlx::{AnyPool, Row};
 
 use crate::models::sessions::{SessionInfo, SessionStatus};
 use crate::models::webhooks::{WebhookConfig, WebhookEvent};
 
 #[derive(Clone)]
 pub struct SessionManager {
-    pool: Pool,
+    pool: AnyPool,
+    backend: DbBackend,
+}
+
+#[derive(Clone, Copy, Debug)]
+enum DbBackend {
+    Postgres,
+    MySQL,
+    SQLite,
+}
+
+fn detect_backend() -> DbBackend {
+    let url = std::env::var("DATABASE_URL").unwrap_or_default();
+    if url.starts_with("postgres") {
+        DbBackend::Postgres
+    } else if url.starts_with("mysql") {
+        DbBackend::MySQL
+    } else {
+        DbBackend::SQLite
+    }
 }
 
 impl SessionManager {
-    pub fn new(pool: Pool) -> Self {
-        Self { pool }
+    pub fn new(pool: AnyPool) -> Self {
+        Self {
+            pool,
+            backend: detect_backend(),
+        }
     }
 
     pub async fn create_session(
@@ -20,48 +42,47 @@ impl SessionManager {
         name: Option<&str>,
         storage_path: &str,
     ) -> anyhow::Result<SessionInfo> {
-        let client = self.pool.get().await?;
+        let name_str = name.unwrap_or("");
 
-        let row = client
-            .query_one(
-                r#"
-                INSERT INTO sessions (id, name, storage_path, status, is_logged_in)
-                VALUES ($1, $2, $3, 'disconnected', FALSE)
-                RETURNING id, name, storage_path, phone_number, push_name, status, is_logged_in, created_at, updated_at, last_connected_at
-                "#,
-                &[&id, &name, &storage_path],
-            )
-            .await?;
+        sqlx::query(
+            "INSERT INTO sessions (id, name, storage_path, status, is_logged_in) VALUES (?, ?, ?, 'disconnected', 0)",
+        )
+        .bind(id)
+        .bind(name_str)
+        .bind(storage_path)
+        .execute(&self.pool)
+        .await?;
 
-        Ok(self.row_to_session_info(&row))
+        // Fetch back
+        let session = self.get_session(id).await?;
+        session.ok_or_else(|| anyhow::anyhow!("Failed to fetch created session"))
     }
 
     pub async fn get_session(&self, id: &str) -> anyhow::Result<Option<SessionInfo>> {
-        let client = self.pool.get().await?;
-
-        let row = client
-            .query_opt("SELECT * FROM sessions WHERE id = $1", &[&id])
-            .await?;
+        let row: Option<AnyRow> =
+            sqlx::query("SELECT * FROM sessions WHERE id = ?")
+                .bind(id)
+                .fetch_optional(&self.pool)
+                .await?;
 
         Ok(row.map(|r| self.row_to_session_info(&r)))
     }
 
     pub async fn get_storage_path(&self, id: &str) -> anyhow::Result<Option<String>> {
-        let client = self.pool.get().await?;
+        let row: Option<AnyRow> =
+            sqlx::query("SELECT storage_path FROM sessions WHERE id = ?")
+                .bind(id)
+                .fetch_optional(&self.pool)
+                .await?;
 
-        let row = client
-            .query_opt("SELECT storage_path FROM sessions WHERE id = $1", &[&id])
-            .await?;
-
-        Ok(row.map(|r| r.get::<_, String>("storage_path")))
+        Ok(row.map(|r| r.get::<String, _>("storage_path")))
     }
 
     pub async fn list_sessions(&self) -> anyhow::Result<Vec<SessionInfo>> {
-        let client = self.pool.get().await?;
-
-        let rows = client
-            .query("SELECT * FROM sessions ORDER BY created_at DESC", &[])
-            .await?;
+        let rows: Vec<AnyRow> =
+            sqlx::query("SELECT * FROM sessions ORDER BY created_at DESC")
+                .fetch_all(&self.pool)
+                .await?;
 
         Ok(rows.iter().map(|r| self.row_to_session_info(r)).collect())
     }
@@ -72,18 +93,30 @@ impl SessionManager {
         status: SessionStatus,
         is_logged_in: bool,
     ) -> anyhow::Result<()> {
-        let client = self.pool.get().await?;
+        let logged_in_val: i32 = if is_logged_in { 1 } else { 0 };
 
-        client
-            .execute(
-                r#"
-                UPDATE sessions
-                SET status = $1, is_logged_in = $2, updated_at = NOW()
-                WHERE id = $3
-                "#,
-                &[&status.as_str(), &is_logged_in, &id],
-            )
-            .await?;
+        match self.backend {
+            DbBackend::SQLite => {
+                sqlx::query(
+                    "UPDATE sessions SET status = ?, is_logged_in = ?, updated_at = datetime('now') WHERE id = ?",
+                )
+                .bind(status.as_str())
+                .bind(logged_in_val)
+                .bind(id)
+                .execute(&self.pool)
+                .await?;
+            }
+            _ => {
+                sqlx::query(
+                    "UPDATE sessions SET status = ?, is_logged_in = ?, updated_at = NOW() WHERE id = ?",
+                )
+                .bind(status.as_str())
+                .bind(logged_in_val)
+                .bind(id)
+                .execute(&self.pool)
+                .await?;
+            }
+        }
 
         Ok(())
     }
@@ -94,49 +127,62 @@ impl SessionManager {
         phone_number: Option<&str>,
         push_name: Option<&str>,
     ) -> anyhow::Result<()> {
-        let client = self.pool.get().await?;
-
-        client
-            .execute(
-                r#"
-                UPDATE sessions
-                SET phone_number = COALESCE($1, phone_number),
-                    push_name = COALESCE($2, push_name),
-                    updated_at = NOW()
-                WHERE id = $3
-                "#,
-                &[&phone_number, &push_name, &id],
-            )
-            .await?;
+        match self.backend {
+            DbBackend::SQLite => {
+                sqlx::query(
+                    "UPDATE sessions SET phone_number = COALESCE(?, phone_number), push_name = COALESCE(?, push_name), updated_at = datetime('now') WHERE id = ?",
+                )
+                .bind(phone_number)
+                .bind(push_name)
+                .bind(id)
+                .execute(&self.pool)
+                .await?;
+            }
+            _ => {
+                sqlx::query(
+                    "UPDATE sessions SET phone_number = COALESCE(?, phone_number), push_name = COALESCE(?, push_name), updated_at = NOW() WHERE id = ?",
+                )
+                .bind(phone_number)
+                .bind(push_name)
+                .bind(id)
+                .execute(&self.pool)
+                .await?;
+            }
+        }
 
         Ok(())
     }
 
     pub async fn update_last_connected(&self, id: &str) -> anyhow::Result<()> {
-        let client = self.pool.get().await?;
-
-        client
-            .execute(
-                r#"
-                UPDATE sessions
-                SET last_connected_at = NOW(), updated_at = NOW()
-                WHERE id = $1
-                "#,
-                &[&id],
-            )
-            .await?;
+        match self.backend {
+            DbBackend::SQLite => {
+                sqlx::query(
+                    "UPDATE sessions SET last_connected_at = datetime('now'), updated_at = datetime('now') WHERE id = ?",
+                )
+                .bind(id)
+                .execute(&self.pool)
+                .await?;
+            }
+            _ => {
+                sqlx::query(
+                    "UPDATE sessions SET last_connected_at = NOW(), updated_at = NOW() WHERE id = ?",
+                )
+                .bind(id)
+                .execute(&self.pool)
+                .await?;
+            }
+        }
 
         Ok(())
     }
 
     pub async fn delete_session(&self, id: &str) -> anyhow::Result<bool> {
-        let client = self.pool.get().await?;
-
-        let result = client
-            .execute("DELETE FROM sessions WHERE id = $1", &[&id])
+        let result = sqlx::query("DELETE FROM sessions WHERE id = ?")
+            .bind(id)
+            .execute(&self.pool)
             .await?;
 
-        Ok(result > 0)
+        Ok(result.rows_affected() > 0)
     }
 
     pub async fn create_webhook(
@@ -145,30 +191,26 @@ impl SessionManager {
         session_id: &str,
         config: &WebhookConfig,
     ) -> anyhow::Result<()> {
-        let client = self.pool.get().await?;
-
-        let events: Vec<String> = config
+        let events_str: String = config
             .events
             .iter()
             .map(|e| e.as_str().to_string())
-            .collect();
+            .collect::<Vec<_>>()
+            .join(",");
 
-        client
-            .execute(
-                r#"
-                INSERT INTO webhooks (id, session_id, url, events, secret, enabled)
-                VALUES ($1, $2, $3, $4, $5, $6)
-                "#,
-                &[
-                    &id,
-                    &session_id,
-                    &config.url,
-                    &events,
-                    &config.secret,
-                    &config.enabled,
-                ],
-            )
-            .await?;
+        let enabled_val: i32 = if config.enabled { 1 } else { 0 };
+
+        sqlx::query(
+            "INSERT INTO webhooks (id, session_id, url, events, secret, enabled) VALUES (?, ?, ?, ?, ?, ?)",
+        )
+        .bind(id)
+        .bind(session_id)
+        .bind(&config.url)
+        .bind(&events_str)
+        .bind(&config.secret)
+        .bind(enabled_val)
+        .execute(&self.pool)
+        .await?;
 
         Ok(())
     }
@@ -178,27 +220,25 @@ impl SessionManager {
         &self,
         session_id: &str,
     ) -> anyhow::Result<Vec<(String, WebhookConfig)>> {
-        let client = self.pool.get().await?;
-
-        let rows = client
-            .query(
-                "SELECT * FROM webhooks WHERE session_id = $1",
-                &[&session_id],
-            )
-            .await?;
+        let rows: Vec<AnyRow> =
+            sqlx::query("SELECT * FROM webhooks WHERE session_id = ?")
+                .bind(session_id)
+                .fetch_all(&self.pool)
+                .await?;
 
         Ok(rows
             .iter()
             .map(|r| {
                 let id: String = r.get("id");
                 let url: String = r.get("url");
-                let events_raw: Vec<String> = r.get("events");
-                let secret: Option<String> = r.get("secret");
-                let enabled: bool = r.get("enabled");
+                let events_raw: String = r.get("events");
+                let secret: Option<String> = r.try_get("secret").ok().flatten();
+                let enabled: bool = r.try_get::<bool, _>("enabled").unwrap_or(true);
 
                 let events: Vec<WebhookEvent> = events_raw
-                    .iter()
-                    .filter_map(|s| WebhookEvent::from_str(s))
+                    .split(',')
+                    .filter(|s| !s.is_empty())
+                    .filter_map(|s| WebhookEvent::from_str(s.trim()))
                     .collect();
 
                 (
@@ -215,31 +255,78 @@ impl SessionManager {
     }
 
     pub async fn delete_webhook(&self, id: &str) -> anyhow::Result<bool> {
-        let client = self.pool.get().await?;
-
-        let result = client
-            .execute("DELETE FROM webhooks WHERE id = $1", &[&id])
+        let result = sqlx::query("DELETE FROM webhooks WHERE id = ?")
+            .bind(id)
+            .execute(&self.pool)
             .await?;
 
-        Ok(result > 0)
+        Ok(result.rows_affected() > 0)
     }
 
-    fn row_to_session_info(&self, row: &tokio_postgres::Row) -> SessionInfo {
-        let created_at: DateTime<Utc> = row.get("created_at");
-        let updated_at: DateTime<Utc> = row.get("updated_at");
-        let last_connected_at: Option<DateTime<Utc>> = row.get("last_connected_at");
+    fn row_to_session_info(&self, row: &AnyRow) -> SessionInfo {
         let status_str: String = row.get("status");
+
+        // Handle timestamps - different backends store differently
+        let created_at = self.get_timestamp(row, "created_at").unwrap_or(0);
+        let updated_at = self.get_timestamp(row, "updated_at").unwrap_or(0);
+        let last_connected_at = self.get_timestamp(row, "last_connected_at");
+
+        // Handle bool - SQLite uses integer
+        let is_logged_in: bool = row.try_get::<bool, _>("is_logged_in")
+            .unwrap_or_else(|_| {
+                row.try_get::<i32, _>("is_logged_in")
+                    .map(|v| v != 0)
+                    .unwrap_or(false)
+            });
 
         SessionInfo {
             id: row.get("id"),
-            name: row.get("name"),
-            phone_number: row.get("phone_number"),
-            push_name: row.get("push_name"),
+            name: row.try_get("name").ok(),
+            phone_number: row.try_get("phone_number").ok().flatten(),
+            push_name: row.try_get("push_name").ok().flatten(),
             status: SessionStatus::from_str(&status_str),
-            created_at: created_at.timestamp(),
-            updated_at: updated_at.timestamp(),
-            last_connected_at: last_connected_at.map(|t| t.timestamp()),
-            is_logged_in: row.get("is_logged_in"),
+            created_at,
+            updated_at,
+            last_connected_at,
+            is_logged_in,
         }
+    }
+
+    fn get_timestamp(&self, row: &AnyRow, col: &str) -> Option<i64> {
+        use sqlx::ValueRef;
+
+        // Check if column is null first
+        let raw = row.try_get_raw(col).ok()?;
+        if raw.is_null() {
+            return None;
+        }
+
+        // Try string representation (works for all backends via Display/text)
+        if let Ok(s) = row.try_get::<String, _>(col) {
+            // Try various datetime formats
+            for fmt in &[
+                "%Y-%m-%d %H:%M:%S%.f%:z", // Postgres TIMESTAMPTZ
+                "%Y-%m-%dT%H:%M:%S%.f%:z", // ISO 8601 with tz
+                "%Y-%m-%d %H:%M:%S%.f",    // MySQL/SQLite with fractional
+                "%Y-%m-%d %H:%M:%S",        // Basic datetime
+                "%Y-%m-%dT%H:%M:%S%.f",    // ISO 8601 no tz
+                "%Y-%m-%dT%H:%M:%S",       // ISO 8601 basic
+            ] {
+                if let Ok(dt) = chrono::NaiveDateTime::parse_from_str(&s, fmt) {
+                    return Some(dt.and_utc().timestamp());
+                }
+                if let Ok(dt) = chrono::DateTime::parse_from_str(&s, fmt) {
+                    return Some(dt.timestamp());
+                }
+            }
+            return None;
+        }
+
+        // Try i64 directly (epoch)
+        if let Ok(ts) = row.try_get::<i64, _>(col) {
+            return Some(ts);
+        }
+
+        None
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,6 @@
 use anyhow::Result;
-use deadpool_postgres::{Manager, ManagerConfig, Pool, RecyclingMethod};
 use std::net::SocketAddr;
 use tokio::net::TcpListener;
-use tokio_postgres::NoTls;
 use tower_http::cors::{Any, CorsLayer};
 use tower_http::trace::TraceLayer;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
@@ -351,37 +349,7 @@ async fn main() -> Result<()> {
 
     tracing::info!("Starting WhatsApp REST API server...");
 
-    let db_host = std::env::var("POSTGRES_HOST").unwrap_or_else(|_| "localhost".to_string());
-    let db_port: u16 = std::env::var("POSTGRES_PORT")
-        .unwrap_or_else(|_| "5432".to_string())
-        .parse()
-        .unwrap_or(5432);
-    let db_user = std::env::var("POSTGRES_USER").unwrap_or_else(|_| "postgres".to_string());
-    let db_password = std::env::var("POSTGRES_PASSWORD").unwrap_or_else(|_| "postgres".to_string());
-    let db_name = std::env::var("POSTGRES_DB").unwrap_or_else(|_| "wagateway".to_string());
-
-    tracing::info!(
-        "Connecting to PostgreSQL at {}:{}/{}",
-        db_host,
-        db_port,
-        db_name
-    );
-
-    let mut pg_config = tokio_postgres::Config::new();
-    pg_config.host(&db_host);
-    pg_config.port(db_port);
-    pg_config.user(&db_user);
-    pg_config.password(&db_password);
-    pg_config.dbname(&db_name);
-
-    let mgr_config = ManagerConfig {
-        recycling_method: RecyclingMethod::Fast,
-    };
-    let mgr = Manager::from_config(pg_config, NoTls, mgr_config);
-    let pool = Pool::builder(mgr).max_size(16).build()?;
-
-    let _ = pool.get().await?;
-    tracing::info!("Connected to PostgreSQL");
+    let pool = db::create_pool().await?;
 
     db::schema::init_schema(&pool).await?;
     tracing::info!("Database schema initialized");

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,6 +1,6 @@
 use dashmap::DashMap;
-use deadpool_postgres::Pool;
 use parking_lot::RwLock;
+use sqlx::AnyPool;
 use std::sync::Arc;
 use tokio::sync::broadcast;
 use whatsapp_rust::Client;
@@ -98,7 +98,7 @@ struct AppStateInner {
 }
 
 impl AppState {
-    pub async fn new(pool: Pool, nats: Option<NatsManager>) -> Self {
+    pub async fn new(pool: AnyPool, nats: Option<NatsManager>) -> Self {
         let base_storage_path = std::env::var("WHATSAPP_STORAGE_PATH")
             .unwrap_or_else(|_| "./whatsapp_sessions".to_string());
 


### PR DESCRIPTION
Replace tokio-postgres/deadpool-postgres with SQLx AnyPool to support multiple database backends. Users can now set DATABASE_URL with any of:
- postgres://user:pass@host/db
- mysql://user:pass@host/db
- sqlite://path.db

Legacy POSTGRES_* env vars still work as fallback. Schema initialization is backend-aware with proper SQL dialect per database.