### PR TITLE
fix: remove hardcoded credentials from Dockerfile and docker-compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,13 +55,7 @@ COPY --from=rust-builder /app/target/release/wa-rs /app/wa-rs
 # Create directory for WhatsApp session storage
 RUN mkdir -p /app/whatsapp_sessions
 
-# Environment variables
-ENV POSTGRES_HOST=postgres
-ENV POSTGRES_PORT=5432
-ENV POSTGRES_USER=postgres
-ENV POSTGRES_PASSWORD=postgres
-ENV POSTGRES_DB=wagateway
-ENV JWT_SECRET=change-this-in-production
+# Environment variables (override via .env or docker-compose)
 ENV WHATSAPP_STORAGE_PATH=/app/whatsapp_sessions
 ENV RUST_LOG=wa_rs=info,tower_http=info
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,16 +2,18 @@ services:
   postgres:
     image: postgres:16
     container_name: wagateway-postgres
+    env_file:
+      - .env
     environment:
-      POSTGRES_USER: ${DB_USER:-postgres}
-      POSTGRES_PASSWORD: ${DB_PASSWORD:-postgres}
-      POSTGRES_DB: ${DB_NAME:-wagateway}
+      POSTGRES_USER: ${DB_USER}
+      POSTGRES_PASSWORD: ${DB_PASSWORD}
+      POSTGRES_DB: ${DB_NAME}
     volumes:
       - postgres_data:/var/lib/postgresql/data
     ports:
       - "5432:5432"
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${DB_USER:-postgres}"]
+      test: ["CMD-SHELL", "pg_isready -U ${DB_USER}"]
       interval: 5s
       timeout: 5s
       retries: 5
@@ -36,7 +38,6 @@ services:
     env_file:
       - .env
     environment:
-      DATABASE_URL: ${DATABASE_URL:-postgres://${DB_USER:-postgres}:${DB_PASSWORD:-postgres}@postgres:5432/${DB_NAME:-wagateway}}
       WHATSAPP_STORAGE_PATH: /app/whatsapp_sessions
       NATS_URL: ${NATS_URL:-nats://nats:4222}
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,15 +3,15 @@ services:
     image: postgres:16
     container_name: wagateway-postgres
     environment:
-      POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: postgres
-      POSTGRES_DB: wagateway
+      POSTGRES_USER: ${DB_USER:-postgres}
+      POSTGRES_PASSWORD: ${DB_PASSWORD:-postgres}
+      POSTGRES_DB: ${DB_NAME:-wagateway}
     volumes:
       - postgres_data:/var/lib/postgresql/data
     ports:
       - "5432:5432"
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      test: ["CMD-SHELL", "pg_isready -U ${DB_USER:-postgres}"]
       interval: 5s
       timeout: 5s
       retries: 5
@@ -33,13 +33,12 @@ services:
       context: .
       dockerfile: Dockerfile
     container_name: wagateway-api
+    env_file:
+      - .env
     environment:
-      DATABASE_URL: postgres://postgres:postgres@postgres:5432/wagateway
-      JWT_SECRET: ${JWT_SECRET:-your-super-secret-jwt-key-change-in-production}
-      SUPERADMIN_TOKEN: ${SUPERADMIN_TOKEN:-}
+      DATABASE_URL: ${DATABASE_URL:-postgres://${DB_USER:-postgres}:${DB_PASSWORD:-postgres}@postgres:5432/${DB_NAME:-wagateway}}
       WHATSAPP_STORAGE_PATH: /app/whatsapp_sessions
-      NATS_URL: nats://nats:4222
-      RUST_LOG: wa_rs=info,tower_http=info
+      NATS_URL: ${NATS_URL:-nats://nats:4222}
     volumes:
       - whatsapp_sessions:/app/whatsapp_sessions
     ports:


### PR DESCRIPTION
- Dockerfile: remove POSTGRES_* and JWT_SECRET env defaults
- docker-compose: use env_file .env, all credentials via env vars
- No more secrets baked into image or compose file