### PR TITLE
v0.2.0: Multi-database support (PostgreSQL, MySQL, SQLite)

### DIFF
--- a/src/db/schema.rs
+++ b/src/db/schema.rs
@@ -107,7 +107,7 @@ async fn init_mysql(pool: &AnyPool) -> anyhow::Result<()> {
             id VARCHAR(255) PRIMARY KEY,
             session_id VARCHAR(255) NOT NULL,
             url TEXT NOT NULL,
-            events TEXT NOT NULL DEFAULT '',
+            events VARCHAR(2000) NOT NULL DEFAULT '',
             secret VARCHAR(255),
             enabled TINYINT(1) NOT NULL DEFAULT 1,
             created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,


### PR DESCRIPTION
## Summary

- **Multi-database support** via SQLx — PostgreSQL, MySQL, and SQLite all supported through `DATABASE_URL` env var
- **Legacy fallback** — existing `POSTGRES_*` env vars still work if `DATABASE_URL` is not set
- **Docker cleaned up** — no more hardcoded credentials in Dockerfile or docker-compose; everything from `.env`
- **Postgres optional** — default compose only runs NATS + API; bundled Postgres available via `docker-compose.postgres.yml`
- **CI/CD fixes** — release workflow now auto-creates git tags, generates changelog, and renders release notes properly
- **Version bump** to 0.2.0

## Changes

- Replace `tokio-postgres` + `deadpool-postgres` with `sqlx` AnyPool
- Backend-aware schema initialization (proper SQL dialect per DB)
- SQLite auto-creates database file
- Fix MySQL strict mode: TEXT column can't have DEFAULT, use VARCHAR
- Fix clippy redundant closure warning
- Remove hardcoded credentials from Dockerfile, docker-compose, .env.example
- Remove donation/support section from README
- Fix release workflow: auto-tag, optional Docker, body_path rendering

## Test plan

- [x] Tested with SQLite backend locally
- [x] Tested with MySQL backend on remote server
- [x] PostgreSQL legacy fallback preserved
- [ ] CI passes (fmt, clippy, build)
- [ ] Release workflow creates tag + GitHub release on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)