### PR TITLE
fix: allow SUPERADMIN_TOKEN as plain string auth, not just JWT

### DIFF
--- a/src/middleware/jwt.rs
+++ b/src/middleware/jwt.rs
@@ -103,6 +103,13 @@ pub async fn jwt_auth_middleware(request: Request<Body>, next: Next) -> Response
         }
     };
 
+    // Check if token matches SUPERADMIN_TOKEN (plain string token)
+    if let Ok(superadmin_token) = std::env::var("SUPERADMIN_TOKEN") {
+        if !superadmin_token.is_empty() && token == superadmin_token {
+            return next.run(request).await;
+        }
+    }
+
     match jwt_auth.validate_token(token) {
         Ok(claims) => {
             if !JwtAuth::is_superadmin(&claims) {


### PR DESCRIPTION
Previously SUPERADMIN_TOKEN was only displayed on startup but the middleware always required a valid JWT. Now if the Bearer token matches SUPERADMIN_TOKEN, it's accepted directly without JWT validation.