### PR TITLE
fix: add missing fake_reply field in send_message SendTextRequest init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,41 @@
 
 All notable changes to **wa-rs** will be documented in this file.
 
+## [0.4.0] - 2026-04-22
+
+### New Features
+
+#### Fake Reply (Anti-Ban Message Wrapping)
+- [x] `fake_reply` field on `POST /sessions/{id}/messages/text` wraps the
+      outgoing text as a reply to a synthesized dummy message
+- [x] 7 reply types: `text`, `product`, `order`, `location`, `video`,
+      `document`, `contact`
+- [x] Indonesian data pools bundled — 29 product names, 12 Jakarta
+      malls/landmarks with real lat/long, 10 contact name templates,
+      realistic IDR price ranges (Rp 15jt - 999jt)
+- [x] Auto-generates participant JID and stanza ID when not provided
+- [x] Takes precedence over `reply_to` when both present
+- [x] New handler module `src/handlers/fake_reply.rs` with
+      `build_fake_reply_context_info()` builder
+
+#### Calls & Status Endpoints (scaffolding)
+- [x] New `src/handlers/calls.rs` + `src/models/calls.rs` for call events
+- [x] New `src/handlers/status.rs` + `src/models/status.rs` for status / story
+
+#### Outbound HTTP Proxy
+- [x] New `src/net.rs` module — reads `WA_PROXY`, `HTTPS_PROXY`, `HTTP_PROXY`
+      env vars for outbound WA media / HTTP calls
+- [x] CLI `--proxy <URL>` flag
+
+### Internal
+- Message `ContextInfo` now wrapped in `Box<>` for the recursive quoted_message type
+- Cargo.toml adds `rand = "0.8"` for data pool selection
+- Version bump 0.2.1 → 0.4.0 (aligns with CHANGELOG which had jumped to 0.3.0)
+
+### Documentation
+- Fake Reply section added to `docs/api/messages.md` with full type
+  reference, field semantics, and cURL examples
+
 ## [0.3.0] - 2026-04-04
 
 ### Breaking Changes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wa-rs"
-version = "0.2.1"
+version = "0.4.0"
 edition = "2021"
 authors = ["taqin"]
 license = "MIT"

--- a/src/handlers/messages.rs
+++ b/src/handlers/messages.rs
@@ -2119,6 +2119,7 @@ pub async fn send_message(
             to: request.to,
             text: request.text,
             reply_to: None,
+            fake_reply: None,
         }),
     )
     .await


### PR DESCRIPTION
v0.4.0 — bump version, CHANGELOG entry for fake_reply, calls, status, and proxy (net module). Fix compile error in send_message handler that constructed SendTextRequest without the new field.