### PR TITLE
feat: add GET /api/v1/info endpoint with self-detected geo location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 All notable changes to **wa-rs** will be documented in this file.
 
+## [0.4.2] - 2026-04-23
+
+### New Features
+
+#### Server Info Endpoint
+- [x] `GET /api/v1/info` — public endpoint that returns server version and
+      self-detected geo location (IP, country code/name, city, region, lat,
+      lon, timezone)
+- [x] Location auto-detection via ip-api.com on first request using the
+      server's own outbound public IP — works correctly for Tailscale /
+      overlay-network deployments where the inbound IP is private (100.64/10)
+- [x] Env override support for all fields: `WA_LOCATION_CODE`,
+      `WA_LOCATION_COUNTRY`, `WA_LOCATION_CITY`, `WA_LOCATION_REGION`,
+      `WA_LOCATION_LAT`, `WA_LOCATION_LON`, `WA_LOCATION_TZ`, `WA_LOCATION_IP`
+- [x] Result cached in process memory for the lifetime of the server
+
+### Rationale
+The adonis gateway previously did DNS resolve + ip-api lookup from its own
+side to get server geo. That fails for servers behind Tailscale since
+private IPs in the CGNAT range have no public geo info. Moving geo detection
+into wa-rs itself means the detection uses the server's own outbound public
+IP, which always works.
+
 ## [0.4.1] - 2026-04-23
 
 ### Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3825,7 +3825,7 @@ checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
 
 [[package]]
 name = "wa-rs"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "async-nats",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wa-rs"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 authors = ["taqin"]
 license = "MIT"

--- a/src/handlers/info.rs
+++ b/src/handlers/info.rs
@@ -1,0 +1,131 @@
+//! Server metadata endpoint — returns version + self-detected geo location.
+//!
+//! The server detects its own public IP and geolocation at first request,
+//! then caches for the lifetime of the process. Admin can override any
+//! field via env vars: WA_LOCATION_CODE, WA_LOCATION_COUNTRY,
+//! WA_LOCATION_CITY, WA_LOCATION_REGION, WA_LOCATION_LAT, WA_LOCATION_LON,
+//! WA_LOCATION_TZ.
+//!
+//! This is needed because some deployments run behind Tailscale or other
+//! overlay networks — the adonis gateway can't resolve their location from
+//! a private 100.64.0.0/10 address. wa-rs itself has outbound internet
+//! access via its real public IP (even if serving via Tailscale), so it
+//! can self-detect reliably.
+
+use axum::Json;
+use serde::{Deserialize, Serialize};
+use tokio::sync::OnceCell;
+use utoipa::ToSchema;
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct LocationInfo {
+    pub ip: Option<String>,
+    pub country_code: Option<String>,
+    pub country_name: Option<String>,
+    pub city: Option<String>,
+    pub region: Option<String>,
+    pub latitude: Option<f64>,
+    pub longitude: Option<f64>,
+    pub timezone: Option<String>,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct ServerInfo {
+    pub version: String,
+    pub location: LocationInfo,
+}
+
+static CACHED_LOCATION: OnceCell<LocationInfo> = OnceCell::const_new();
+
+fn env_opt(key: &str) -> Option<String> {
+    std::env::var(key).ok().filter(|s| !s.trim().is_empty())
+}
+
+fn location_from_env() -> Option<LocationInfo> {
+    let code = env_opt("WA_LOCATION_CODE");
+    let country = env_opt("WA_LOCATION_COUNTRY");
+    let city = env_opt("WA_LOCATION_CITY");
+    let region = env_opt("WA_LOCATION_REGION");
+
+    if code.is_none() && country.is_none() && city.is_none() {
+        return None;
+    }
+
+    Some(LocationInfo {
+        ip: env_opt("WA_LOCATION_IP"),
+        country_code: code,
+        country_name: country,
+        city: city.clone(),
+        region: region.or(city),
+        latitude: env_opt("WA_LOCATION_LAT").and_then(|v| v.parse().ok()),
+        longitude: env_opt("WA_LOCATION_LON").and_then(|v| v.parse().ok()),
+        timezone: env_opt("WA_LOCATION_TZ"),
+    })
+}
+
+#[derive(Deserialize)]
+struct IpApiResponse {
+    status: String,
+    query: Option<String>,
+    country: Option<String>,
+    #[serde(rename = "countryCode")]
+    country_code: Option<String>,
+    city: Option<String>,
+    #[serde(rename = "regionName")]
+    region: Option<String>,
+    lat: Option<f64>,
+    lon: Option<f64>,
+    timezone: Option<String>,
+}
+
+async fn fetch_ipapi() -> Option<LocationInfo> {
+    let url = "http://ip-api.com/json/?fields=status,query,country,countryCode,city,regionName,lat,lon,timezone";
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(5))
+        .build()
+        .ok()?;
+
+    let body = client.get(url).send().await.ok()?.text().await.ok()?;
+    let resp: IpApiResponse = serde_json::from_str(&body).ok()?;
+    if resp.status != "success" {
+        return None;
+    }
+
+    let city = resp.city.clone();
+    Some(LocationInfo {
+        ip: resp.query,
+        country_code: resp.country_code,
+        country_name: resp.country,
+        city,
+        region: resp.region,
+        latitude: resp.lat,
+        longitude: resp.lon,
+        timezone: resp.timezone,
+    })
+}
+
+async fn detect_location() -> LocationInfo {
+    // Env override takes precedence
+    if let Some(loc) = location_from_env() {
+        return loc;
+    }
+    // Auto-detect via ip-api.com (server's outbound public IP)
+    fetch_ipapi().await.unwrap_or(LocationInfo {
+        ip: None,
+        country_code: None,
+        country_name: None,
+        city: None,
+        region: None,
+        latitude: None,
+        longitude: None,
+        timezone: None,
+    })
+}
+
+pub async fn get_info() -> Json<ServerInfo> {
+    let location = CACHED_LOCATION.get_or_init(detect_location).await.clone();
+    Json(ServerInfo {
+        version: env!("CARGO_PKG_VERSION").to_string(),
+        location,
+    })
+}

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -5,6 +5,7 @@ pub mod contacts;
 pub mod fake_reply;
 pub mod groups;
 pub mod groups_management;
+pub mod info;
 pub mod media;
 pub mod messages;
 pub mod mex;

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -10,6 +10,7 @@ pub fn create_router() -> Router<AppState> {
     Router::new()
         .nest("/api/v1", api_routes())
         .route("/health", get(health_check))
+        .route("/api/v1/info", get(handlers::info::get_info))
 }
 
 fn api_routes() -> Router<AppState> {


### PR DESCRIPTION
Adds a public endpoint that returns server version + geo metadata:

  {
    "version": "0.4.2",
    "location": {
      "ip": "52.221.242.70",
      "country_code": "SG",
      "country_name": "Singapore",
      "city": "Singapore",
      "region": "Singapore",
      "latitude": 1.2897,
      "longitude": 103.8501,
      "timezone": "Asia/Singapore"
    }
  }

Detection strategy:
1. Check env override (WA_LOCATION_CODE/COUNTRY/CITY/REGION/LAT/LON/TZ/IP). If any of code/country/city is set, skip auto-detect.
2. Otherwise query ip-api.com from the server's outbound public IP. Cached in-process for the lifetime of the server.

Why: wa-rs can run behind Tailscale with private 100.64/10 addresses. The adonis gateway cannot resolve geo for those. But wa-rs itself has outbound internet access via its real public IP, so self-detection from the server side works reliably.

Version bump 0.4.1 → 0.4.2.