### PR TITLE
feat: fake_reply support for image/video/document send handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to **wa-rs** will be documented in this file.
 
+## [0.4.3] - 2026-04-24
+
+### New Features
+
+#### Fake Reply Support for Media Messages
+- [x] `SendImageRequest`, `SendVideoRequest`, `SendDocumentRequest` now accept
+      an optional `fake_reply: FakeReplyConfig` field (same shape as
+      `send_text`)
+- [x] When `fake_reply` is set, the outgoing media message is wrapped with a
+      synthesized `ContextInfo` so it appears as a reply to a fake product /
+      order / location / video / document / contact / text message — same
+      mechanic already used by `send_text`
+- [x] `fake_reply` takes priority over `reply_to` when both are provided
+
+### Rationale
+Previously only `send_text` could produce the "fake reply" effect used by
+blast to mimic natural conversation. Media sends (image/video/document) now
+support the same trick.
+
 ## [0.4.2] - 2026-04-23
 
 ### New Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 All notable changes to **wa-rs** will be documented in this file.
 
+## [0.4.5] - 2026-04-27
+
+### Fixes
+
+#### Webhook message events now carry actual content
+- [x] `Event::Message` payload was previously serialized with only the
+      envelope (`from`, `chat`, `message_id`, `timestamp`, `is_from_me`).
+      The actual message body — `conversation`, `extended_text_message.text`,
+      `image_message.caption`, etc. — was discarded entirely, so consumers
+      had to call `/messages` to get content.
+- [x] New helper `extract_message_content` reads the wa::Message protobuf
+      and emits: `text`, `caption`, `message_type` (one of `text`, `image`,
+      `video`, `audio`, `ptt`, `document`, `sticker`, `location`, `contact`,
+      `contacts`, `poll`, `poll_vote`, `reaction`, `buttons`, `list`,
+      `template`, `unknown`), and `media_mimetype`.
+- [x] Event payload also adds `push_name`, `verified_name`, top-level
+      `type`, `media_type`, `is_group`, and `participant`.
+
+### Rationale
+Inbox UIs that listened to webhooks couldn't render text/media without
+re-fetching. With content inline, downstream consumers like MAUBLAST
+can persist a real conversation log on a single round trip.
+
 ## [0.4.4] - 2026-04-26
 
 ### New Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to **wa-rs** will be documented in this file.
 
+## [0.4.4] - 2026-04-26
+
+### New Features
+
+#### Custom device-props at pair time
+- [x] New module `device_props` resolves how each session shows up in
+      WhatsApp's "Linked Devices" list. Default is now `os = "Windows"`
+      and `platform = Chrome` instead of the upstream `"rust"` /
+      `Unknown` defaults.
+- [x] Override globally via env: `WA_DEVICE_OS` (string, e.g. `Windows`,
+      `Mac OS X`, `Ubuntu`) and `WA_DEVICE_PLATFORM` (one of `chrome`,
+      `firefox`, `edge`, `safari`, `opera`, `ie`, `desktop`, `ipad`,
+      `android_phone`, `android_tablet`, `ios_phone`).
+- [x] Both QR-code and pair-code connect paths now call
+      `Bot::builder().with_device_props(...)`. The pair-code
+      `platform_display` string also picks up the resolved OS.
+
+### Rationale
+Previously sessions appeared as "Rust" / "Unknown device" in the
+recipient's linked-devices list, which was both visually off-brand and
+arguably more flagged-prone than mimicking a stock browser pairing.
+
 ## [0.4.3] - 2026-04-24
 
 ### New Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3825,7 +3825,7 @@ checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
 
 [[package]]
 name = "wa-rs"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "anyhow",
  "async-nats",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3825,7 +3825,7 @@ checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
 
 [[package]]
 name = "wa-rs"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "anyhow",
  "async-nats",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3825,7 +3825,7 @@ checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
 
 [[package]]
 name = "wa-rs"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "anyhow",
  "async-nats",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wa-rs"
-version = "0.4.3"
+version = "0.4.4"
 edition = "2021"
 authors = ["taqin"]
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wa-rs"
-version = "0.4.4"
+version = "0.4.5"
 edition = "2021"
 authors = ["taqin"]
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wa-rs"
-version = "0.4.2"
+version = "0.4.3"
 edition = "2021"
 authors = ["taqin"]
 license = "MIT"

--- a/src/device_props.rs
+++ b/src/device_props.rs
@@ -1,0 +1,47 @@
+//! Device props resolver — controls how each session appears in WhatsApp's
+//! "Linked Devices" list at pair time.
+//!
+//! Defaults: `os = "Windows"`, `platform = Chrome`. Override globally via env:
+//!   `WA_DEVICE_OS`        — e.g. "Windows", "Mac OS X", "Ubuntu"
+//!   `WA_DEVICE_PLATFORM`  — one of: chrome, firefox, edge, safari, opera,
+//!                          ie, desktop, ipad, android_phone, android_tablet
+//!
+//! These only take effect at the first pairing — once the device is registered,
+//! whatsapp-rust persists the props in its SQLite store and re-uses them on
+//! subsequent connects.
+
+use waproto::whatsapp as wa;
+
+#[derive(Debug, Clone)]
+pub struct ResolvedDeviceProps {
+    pub os: String,
+    pub platform: wa::device_props::PlatformType,
+}
+
+pub fn resolve_from_env() -> ResolvedDeviceProps {
+    let os = std::env::var("WA_DEVICE_OS").unwrap_or_else(|_| "Windows".to_string());
+    let platform = std::env::var("WA_DEVICE_PLATFORM")
+        .ok()
+        .as_deref()
+        .map(parse_platform)
+        .unwrap_or(wa::device_props::PlatformType::Chrome);
+    ResolvedDeviceProps { os, platform }
+}
+
+fn parse_platform(s: &str) -> wa::device_props::PlatformType {
+    use wa::device_props::PlatformType as P;
+    match s.trim().to_ascii_lowercase().as_str() {
+        "chrome" => P::Chrome,
+        "firefox" => P::Firefox,
+        "edge" => P::Edge,
+        "safari" => P::Safari,
+        "opera" => P::Opera,
+        "ie" => P::Ie,
+        "desktop" => P::Desktop,
+        "ipad" => P::Ipad,
+        "android_phone" | "android" => P::AndroidPhone,
+        "android_tablet" => P::AndroidTablet,
+        "ios_phone" | "iphone" => P::IosPhone,
+        _ => P::Chrome,
+    }
+}

--- a/src/handlers/messages.rs
+++ b/src/handlers/messages.rs
@@ -103,6 +103,18 @@ pub async fn send_image(
         .await
         .map_err(|e| ApiError::MediaUploadFailed(e.to_string()))?;
 
+    let context_info: Option<Box<waproto::whatsapp::ContextInfo>> =
+        if let Some(ref fake) = request.fake_reply {
+            crate::handlers::fake_reply::build_fake_reply_context_info(fake).map(Box::new)
+        } else {
+            request.reply_to.map(|id| {
+                Box::new(waproto::whatsapp::ContextInfo {
+                    stanza_id: Some(id),
+                    ..Default::default()
+                })
+            })
+        };
+
     let message = waproto::whatsapp::Message {
         image_message: Some(Box::new(waproto::whatsapp::message::ImageMessage {
             url: Some(upload.url),
@@ -113,6 +125,7 @@ pub async fn send_image(
             file_length: Some(data.len() as u64),
             mimetype: Some(mimetype),
             caption: request.caption,
+            context_info,
             ..Default::default()
         })),
         ..Default::default()
@@ -166,6 +179,18 @@ pub async fn send_video(
         .await
         .map_err(|e| ApiError::MediaUploadFailed(e.to_string()))?;
 
+    let context_info: Option<Box<waproto::whatsapp::ContextInfo>> =
+        if let Some(ref fake) = request.fake_reply {
+            crate::handlers::fake_reply::build_fake_reply_context_info(fake).map(Box::new)
+        } else {
+            request.reply_to.map(|id| {
+                Box::new(waproto::whatsapp::ContextInfo {
+                    stanza_id: Some(id),
+                    ..Default::default()
+                })
+            })
+        };
+
     let message = waproto::whatsapp::Message {
         video_message: Some(Box::new(waproto::whatsapp::message::VideoMessage {
             url: Some(upload.url),
@@ -176,6 +201,7 @@ pub async fn send_video(
             file_length: Some(data.len() as u64),
             mimetype: Some(mimetype),
             caption: request.caption,
+            context_info,
             ..Default::default()
         })),
         ..Default::default()
@@ -292,6 +318,18 @@ pub async fn send_document(
         .await
         .map_err(|e| ApiError::MediaUploadFailed(e.to_string()))?;
 
+    let context_info: Option<Box<waproto::whatsapp::ContextInfo>> =
+        if let Some(ref fake) = request.fake_reply {
+            crate::handlers::fake_reply::build_fake_reply_context_info(fake).map(Box::new)
+        } else {
+            request.reply_to.map(|id| {
+                Box::new(waproto::whatsapp::ContextInfo {
+                    stanza_id: Some(id),
+                    ..Default::default()
+                })
+            })
+        };
+
     let message = waproto::whatsapp::Message {
         document_message: Some(Box::new(waproto::whatsapp::message::DocumentMessage {
             url: Some(upload.url),
@@ -303,6 +341,7 @@ pub async fn send_document(
             mimetype: Some(mimetype),
             file_name: Some(request.filename),
             caption: request.caption,
+            context_info,
             ..Default::default()
         })),
         ..Default::default()

--- a/src/handlers/sessions.rs
+++ b/src/handlers/sessions.rs
@@ -535,11 +535,14 @@ async fn connect_client(state: &AppState, session_id: &str) -> Result<(), ApiErr
     let state_for_events = state.clone();
     let session_id_for_events = session_id.to_string();
 
+    let dp = crate::device_props::resolve_from_env();
+
     let mut bot = Bot::builder()
         .with_backend(Arc::new(backend))
         .with_transport_factory(transport_factory)
         .with_http_client(http_client)
         .with_runtime(TokioRuntime)
+        .with_device_props(Some(dp.os), None, Some(dp.platform))
         .on_event(move |event, client| {
             let state = state_for_events.clone();
             let session_id = session_id_for_events.clone();
@@ -612,12 +615,13 @@ async fn connect_client_with_pair_code(
     let state_for_events = state.clone();
     let session_id_for_events = session_id.to_string();
 
+    let dp = crate::device_props::resolve_from_env();
     let pair_options = PairCodeOptions {
         phone_number: phone_number.to_string(),
         show_push_notification: show_notification,
         custom_code: None,
         platform_id: whatsapp_rust::pair_code::PlatformId::Chrome,
-        platform_display: "Chrome (Linux)".to_string(),
+        platform_display: format!("Chrome ({})", dp.os),
     };
 
     let mut bot = Bot::builder()
@@ -626,6 +630,7 @@ async fn connect_client_with_pair_code(
         .with_http_client(http_client)
         .with_runtime(TokioRuntime)
         .with_pair_code(pair_options)
+        .with_device_props(Some(dp.os.clone()), None, Some(dp.platform))
         .on_event(move |event, client| {
             let state = state_for_events.clone();
             let session_id = session_id_for_events.clone();

--- a/src/handlers/sessions.rs
+++ b/src/handlers/sessions.rs
@@ -788,6 +788,95 @@ fn get_event_type(event: &wacore::types::events::Event) -> String {
     }
 }
 
+/// Extracts user-visible content from a protobuf Message: best-effort text,
+/// optional caption, the high-level type slug, and the media mimetype if any.
+fn extract_message_content(
+    msg: &waproto::whatsapp::Message,
+) -> (Option<String>, Option<String>, String, Option<String>) {
+    let mut text: Option<String> = None;
+    let mut caption: Option<String> = None;
+    let mut message_type = "unknown".to_string();
+    let mut media_mimetype: Option<String> = None;
+
+    if let Some(t) = &msg.conversation {
+        if !t.is_empty() {
+            text = Some(t.clone());
+            message_type = "text".to_string();
+        }
+    }
+    if message_type == "unknown" {
+        if let Some(e) = msg.extended_text_message.as_ref() {
+            text = e.text.clone();
+            message_type = "text".to_string();
+        } else if let Some(im) = msg.image_message.as_ref() {
+            caption = im.caption.clone();
+            media_mimetype = im.mimetype.clone();
+            message_type = "image".to_string();
+        } else if let Some(vm) = msg.video_message.as_ref() {
+            caption = vm.caption.clone();
+            media_mimetype = vm.mimetype.clone();
+            message_type = "video".to_string();
+        } else if let Some(am) = msg.audio_message.as_ref() {
+            media_mimetype = am.mimetype.clone();
+            message_type = if am.ptt.unwrap_or(false) {
+                "ptt".to_string()
+            } else {
+                "audio".to_string()
+            };
+        } else if let Some(dm) = msg.document_message.as_ref() {
+            caption = dm.caption.clone();
+            text = dm.file_name.clone();
+            media_mimetype = dm.mimetype.clone();
+            message_type = "document".to_string();
+        } else if let Some(sm) = msg.sticker_message.as_ref() {
+            media_mimetype = sm.mimetype.clone();
+            message_type = "sticker".to_string();
+        } else if msg.location_message.is_some() || msg.live_location_message.is_some() {
+            message_type = "location".to_string();
+        } else if msg.contact_message.is_some() {
+            message_type = "contact".to_string();
+            text = msg
+                .contact_message
+                .as_ref()
+                .and_then(|c| c.display_name.clone());
+        } else if msg.contacts_array_message.is_some() {
+            message_type = "contacts".to_string();
+        } else if msg.poll_creation_message.is_some()
+            || msg.poll_creation_message_v2.is_some()
+            || msg.poll_creation_message_v3.is_some()
+        {
+            message_type = "poll".to_string();
+            text = msg
+                .poll_creation_message
+                .as_ref()
+                .and_then(|p| p.name.clone())
+                .or_else(|| {
+                    msg.poll_creation_message_v2
+                        .as_ref()
+                        .and_then(|p| p.name.clone())
+                })
+                .or_else(|| {
+                    msg.poll_creation_message_v3
+                        .as_ref()
+                        .and_then(|p| p.name.clone())
+                });
+        } else if msg.poll_update_message.is_some() {
+            message_type = "poll_vote".to_string();
+        } else if msg.reaction_message.is_some() {
+            message_type = "reaction".to_string();
+            text = msg.reaction_message.as_ref().and_then(|r| r.text.clone());
+        } else if msg.buttons_message.is_some() {
+            message_type = "buttons".to_string();
+        } else if msg.list_message.is_some() {
+            message_type = "list".to_string();
+        } else if msg.template_message.is_some() {
+            message_type = "template".to_string();
+        }
+    }
+
+    (text, caption, message_type, media_mimetype)
+}
+
 fn event_to_json(event: &wacore::types::events::Event, session_id: &str) -> serde_json::Value {
     use wacore::types::events::Event;
 
@@ -795,13 +884,24 @@ fn event_to_json(event: &wacore::types::events::Event, session_id: &str) -> serd
     let timestamp = chrono::Utc::now().timestamp();
 
     let data = match event {
-        Event::Message(_msg, info) => {
+        Event::Message(msg, info) => {
+            let (text, caption, message_type, media_mimetype) = extract_message_content(msg);
             serde_json::json!({
                 "from": info.source.sender.to_string(),
                 "chat": info.source.chat.to_string(),
                 "message_id": info.id.to_string(),
                 "timestamp": info.timestamp,
                 "is_from_me": info.source.is_from_me,
+                "push_name": info.push_name,
+                "verified_name": info.verified_name.as_ref().map(|c| format!("{:?}", c)),
+                "type": info.r#type,
+                "media_type": info.media_type,
+                "message_type": message_type,
+                "text": text,
+                "caption": caption,
+                "media_mimetype": media_mimetype,
+                "is_group": info.source.chat.to_string().ends_with("@g.us"),
+                "participant": info.source.sender.to_string(),
             })
         }
         Event::Receipt(receipt) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,6 +19,7 @@ const BANNER: &str = r#"
 "#;
 
 mod db;
+mod device_props;
 mod error;
 mod handlers;
 mod middleware;

--- a/src/models/messages.rs
+++ b/src/models/messages.rs
@@ -47,6 +47,8 @@ pub struct SendImageRequest {
     pub caption: Option<String>,
 
     pub reply_to: Option<String>,
+
+    pub fake_reply: Option<FakeReplyConfig>,
 }
 
 #[derive(Debug, Deserialize, ToSchema)]
@@ -60,6 +62,8 @@ pub struct SendVideoRequest {
     pub caption: Option<String>,
 
     pub reply_to: Option<String>,
+
+    pub fake_reply: Option<FakeReplyConfig>,
 }
 
 #[derive(Debug, Deserialize, ToSchema)]
@@ -90,6 +94,8 @@ pub struct SendDocumentRequest {
     pub caption: Option<String>,
 
     pub reply_to: Option<String>,
+
+    pub fake_reply: Option<FakeReplyConfig>,
 }
 
 #[derive(Debug, Deserialize, ToSchema)]


### PR DESCRIPTION
Adds optional fake_reply field to SendImageRequest, SendVideoRequest,
and SendDocumentRequest. When provided, synthesizes a ContextInfo so the
outgoing media appears as a reply to a fake message (product, order,
location, video, document, contact, or text) — same mechanic already used
by send_text. fake_reply takes priority over reply_to.

Bumps version to 0.4.3.Adds optional fake_reply field to SendImageRequest, SendVideoRequest,
and SendDocumentRequest. When provided, synthesizes a ContextInfo so the
outgoing media appears as a reply to a fake message (product, order,
location, video, document, contact, or text) — same mechanic already used
by send_text. fake_reply takes priority over reply_to.

Bumps version to 0.4.3.