### PR TITLE
feat: auto-reconnect every previously-paired session on engine startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to **wa-rs** will be documented in this file.
 
+## [0.4.7] - 2026-04-27
+
+### New Features
+
+#### Media metadata in webhook event payload
+- [x] Inbound `image`, `video`, `audio`, `document`, `sticker` messages
+      now include a `media` object in the webhook payload with
+      `direct_path`, `media_key`, `file_sha256`, `file_enc_sha256`,
+      `file_length`, `mimetype`, plus type-specific fields (width/height
+      for image, seconds + ptt for audio, file_name for document).
+- [x] All binary fields are base64-encoded so the webhook payload is
+      transport-safe JSON.
+- [x] Consumers can take this metadata directly to
+      `POST /sessions/:id/media/download` to fetch the decrypted bytes
+      without an extra metadata round trip.
+
+### Rationale
+Inbox UIs that want to render incoming images / play audio messages
+need the encryption metadata; previously they had to call `/messages`
+or build a chat dump pipeline. With media inline on the event,
+end-to-end render is one round trip away.
+
 ## [0.4.6] - 2026-04-27
 
 ### New Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to **wa-rs** will be documented in this file.
 
+## [0.4.6] - 2026-04-27
+
+### New Features
+
+#### Auto-reconnect on engine startup
+- [x] On boot, the engine now walks every session in DB and spawns a
+      background reconnect for any session that was previously logged-in
+      or in a connecting state. Sessions that were never paired (or
+      explicitly logged out) stay disconnected until manually paired.
+- [x] Reconnects are staggered with a 500ms gap between sessions to
+      avoid hammering WhatsApp's connection endpoint after a deploy.
+- [x] Bumped to 0.4.6.
+
+### Rationale
+Engine restarts (deploys, crashes, host reboots) used to leave every
+paired session offline until a human manually clicked "Connect" in the
+dashboard for each one — painful with many sessions and lossy for users
+expecting always-on operation.
+
 ## [0.4.5] - 2026-04-27
 
 ### Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3825,7 +3825,7 @@ checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
 
 [[package]]
 name = "wa-rs"
-version = "0.4.6"
+version = "0.4.7"
 dependencies = [
  "anyhow",
  "async-nats",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3825,7 +3825,7 @@ checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
 
 [[package]]
 name = "wa-rs"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "anyhow",
  "async-nats",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wa-rs"
-version = "0.4.6"
+version = "0.4.7"
 edition = "2021"
 authors = ["taqin"]
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wa-rs"
-version = "0.4.5"
+version = "0.4.6"
 edition = "2021"
 authors = ["taqin"]
 license = "MIT"

--- a/src/handlers/sessions.rs
+++ b/src/handlers/sessions.rs
@@ -510,6 +510,69 @@ pub async fn get_device_info(
     }))
 }
 
+/// On engine boot, walk every previously-paired session and start a
+/// reconnect attempt in the background. Sessions that have no stored
+/// credentials (never paired or freshly logged out) are skipped — those
+/// stay disconnected until the user re-pairs from the dashboard.
+pub async fn reconnect_all_on_startup(state: AppState) {
+    let sessions = match state.session_manager().list_sessions().await {
+        Ok(s) => s,
+        Err(e) => {
+            tracing::error!("[startup] list_sessions failed: {}", e);
+            return;
+        }
+    };
+
+    tracing::info!(
+        "[startup] auto-reconnect: found {} sessions in DB",
+        sessions.len()
+    );
+
+    for session in sessions {
+        // Only auto-reconnect sessions that were previously logged in OR
+        // were already trying to connect. Disconnected/never-paired sessions
+        // require a manual pair from the dashboard.
+        let should_reconnect = matches!(
+            session.status,
+            SessionStatus::LoggedIn | SessionStatus::Connected | SessionStatus::Connecting
+        ) || session.is_logged_in;
+        if !should_reconnect {
+            tracing::debug!(
+                "[startup] skip session {} (status={:?})",
+                session.id,
+                session.status
+            );
+            continue;
+        }
+
+        let storage_path = match state.session_manager().get_storage_path(&session.id).await {
+            Ok(Some(p)) => p,
+            _ => {
+                tracing::warn!("[startup] no storage path for session {}", session.id);
+                continue;
+            }
+        };
+
+        let runtime = state.get_or_create_session(&session.id, &storage_path);
+        runtime.set_status(SessionStatus::Connecting);
+
+        let state_clone = state.clone();
+        let sid = session.id.clone();
+        tokio::spawn(async move {
+            tracing::info!("[startup] reconnecting session {}", sid);
+            if let Err(e) = connect_client(&state_clone, &sid).await {
+                tracing::warn!("[startup] reconnect failed for {}: {}", sid, e);
+                if let Some(runtime) = state_clone.get_session(&sid) {
+                    runtime.set_status(SessionStatus::Disconnected);
+                }
+            }
+        });
+
+        // Stagger to avoid thundering herd on the WhatsApp servers
+        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+    }
+}
+
 async fn connect_client(state: &AppState, session_id: &str) -> Result<(), ApiError> {
     use whatsapp_rust::bot::Bot;
     use whatsapp_rust::TokioRuntime;

--- a/src/handlers/sessions.rs
+++ b/src/handlers/sessions.rs
@@ -851,6 +851,79 @@ fn get_event_type(event: &wacore::types::events::Event) -> String {
     }
 }
 
+/// Build the metadata blob a downstream consumer needs to call
+/// /sessions/:id/media/download for an inbound media message. Returns null
+/// for non-media or text-only messages.
+fn extract_media_metadata(msg: &waproto::whatsapp::Message) -> serde_json::Value {
+    use base64::Engine as _;
+    fn b64(b: &[u8]) -> String {
+        base64::engine::general_purpose::STANDARD.encode(b)
+    }
+
+    if let Some(im) = msg.image_message.as_ref() {
+        return serde_json::json!({
+            "kind": "image",
+            "direct_path": im.direct_path,
+            "media_key": im.media_key.as_ref().map(|b| b64(b)),
+            "file_sha256": im.file_sha256.as_ref().map(|b| b64(b)),
+            "file_enc_sha256": im.file_enc_sha256.as_ref().map(|b| b64(b)),
+            "file_length": im.file_length,
+            "mimetype": im.mimetype,
+            "width": im.width,
+            "height": im.height,
+        });
+    }
+    if let Some(vm) = msg.video_message.as_ref() {
+        return serde_json::json!({
+            "kind": "video",
+            "direct_path": vm.direct_path,
+            "media_key": vm.media_key.as_ref().map(|b| b64(b)),
+            "file_sha256": vm.file_sha256.as_ref().map(|b| b64(b)),
+            "file_enc_sha256": vm.file_enc_sha256.as_ref().map(|b| b64(b)),
+            "file_length": vm.file_length,
+            "mimetype": vm.mimetype,
+            "seconds": vm.seconds,
+        });
+    }
+    if let Some(am) = msg.audio_message.as_ref() {
+        return serde_json::json!({
+            "kind": "audio",
+            "direct_path": am.direct_path,
+            "media_key": am.media_key.as_ref().map(|b| b64(b)),
+            "file_sha256": am.file_sha256.as_ref().map(|b| b64(b)),
+            "file_enc_sha256": am.file_enc_sha256.as_ref().map(|b| b64(b)),
+            "file_length": am.file_length,
+            "mimetype": am.mimetype,
+            "seconds": am.seconds,
+            "ptt": am.ptt,
+        });
+    }
+    if let Some(dm) = msg.document_message.as_ref() {
+        return serde_json::json!({
+            "kind": "document",
+            "direct_path": dm.direct_path,
+            "media_key": dm.media_key.as_ref().map(|b| b64(b)),
+            "file_sha256": dm.file_sha256.as_ref().map(|b| b64(b)),
+            "file_enc_sha256": dm.file_enc_sha256.as_ref().map(|b| b64(b)),
+            "file_length": dm.file_length,
+            "mimetype": dm.mimetype,
+            "file_name": dm.file_name,
+        });
+    }
+    if let Some(sm) = msg.sticker_message.as_ref() {
+        return serde_json::json!({
+            "kind": "sticker",
+            "direct_path": sm.direct_path,
+            "media_key": sm.media_key.as_ref().map(|b| b64(b)),
+            "file_sha256": sm.file_sha256.as_ref().map(|b| b64(b)),
+            "file_enc_sha256": sm.file_enc_sha256.as_ref().map(|b| b64(b)),
+            "file_length": sm.file_length,
+            "mimetype": sm.mimetype,
+        });
+    }
+    serde_json::Value::Null
+}
+
 /// Extracts user-visible content from a protobuf Message: best-effort text,
 /// optional caption, the high-level type slug, and the media mimetype if any.
 fn extract_message_content(
@@ -949,6 +1022,7 @@ fn event_to_json(event: &wacore::types::events::Event, session_id: &str) -> serd
     let data = match event {
         Event::Message(msg, info) => {
             let (text, caption, message_type, media_mimetype) = extract_message_content(msg);
+            let media_meta = extract_media_metadata(msg);
             serde_json::json!({
                 "from": info.source.sender.to_string(),
                 "chat": info.source.chat.to_string(),
@@ -963,6 +1037,7 @@ fn event_to_json(event: &wacore::types::events::Event, session_id: &str) -> serd
                 "text": text,
                 "caption": caption,
                 "media_mimetype": media_mimetype,
+                "media": media_meta,
                 "is_group": info.source.chat.to_string().ends_with("@g.us"),
                 "participant": info.source.sender.to_string(),
             })

--- a/src/main.rs
+++ b/src/main.rs
@@ -499,6 +499,14 @@ async fn main() -> Result<()> {
     let nats_enabled = nats_manager.is_some();
     let state = AppState::new(pool, nats_manager).await;
 
+    // Auto-reconnect previously-paired sessions in the background. Runs
+    // concurrently with the rest of startup so the HTTP server doesn't
+    // block waiting on WhatsApp socket handshakes.
+    let reconnect_state = state.clone();
+    tokio::spawn(async move {
+        handlers::sessions::reconnect_all_on_startup(reconnect_state).await;
+    });
+
     // Start NATS outbound consumer if enabled
     if nats_enabled {
         if let Some(nats) = state.nats() {


### PR DESCRIPTION
When the engine restarts (deploy, crash, host reboot), all sessions that
were logged-in beforehand used to drop to disconnected and stay there
until a human clicked Connect in the dashboard for each one. New
public reconnect_all_on_startup() walks session_manager.list_sessions()
and spawns connect_client per session that was logged-in / connecting
before the restart. Stagger 500ms between spawns so we don't dogpile
WhatsApp's auth endpoint when 50+ sessions reconnect at once.

main.rs fires it as a tokio::spawn after AppState::new so HTTP startup
doesn't block on socket handshakes. Sessions that were never paired or
were explicitly logged out are skipped — those still need a human pair.

Bumped to 0.4.6.