### PR TITLE
style: rustfmt fix for v0.5.0

### DIFF
--- a/src/handlers/messages.rs
+++ b/src/handlers/messages.rs
@@ -946,7 +946,10 @@ pub async fn send_cta_url(
     let client = get_client(&state, &session_id)?;
     let to_jid = parse_jid(&request.to)?;
 
-    let merchant_url = request.merchant_url.clone().unwrap_or_else(|| request.url.clone());
+    let merchant_url = request
+        .merchant_url
+        .clone()
+        .unwrap_or_else(|| request.url.clone());
     let params = serde_json::json!({
         "display_text": request.display_text,
         "url": request.url,
@@ -1024,7 +1027,9 @@ pub async fn send_quick_reply(
     let to_jid = parse_jid(&request.to)?;
 
     if request.buttons.is_empty() {
-        return Err(ApiError::Internal("buttons must contain 1 to 3 items".into()));
+        return Err(ApiError::Internal(
+            "buttons must contain 1 to 3 items".into(),
+        ));
     }
 
     let buttons: Vec<

--- a/src/handlers/mex.rs
+++ b/src/handlers/mex.rs
@@ -18,7 +18,10 @@ fn build_mex_doc(name: Option<String>, id: String, fallback_name: &'static str) 
         _ => fallback_name,
     };
     let id_str: &'static str = Box::leak(id.into_boxed_str());
-    MexDoc { name: name_str, id: id_str }
+    MexDoc {
+        name: name_str,
+        id: id_str,
+    }
 }
 
 #[utoipa::path(


### PR DESCRIPTION
Trailing rustfmt cleanup after the v0.6.0 lib bump merge. Just line-break formatting — no behavior change.